### PR TITLE
Fix code scanning alert no. 10: Incomplete multi-character sanitization

### DIFF
--- a/src/modules/file/file.controller.ts
+++ b/src/modules/file/file.controller.ts
@@ -102,7 +102,10 @@ export class FileController extends BaseController {
   ) {
     try {
       // Sanitize the path to prevent directory traversal
-      const sanitizedPath = path.replace(/\.\.\//g, '');
+      let sanitizedPath = path;
+      while (sanitizedPath.includes('../')) {
+        sanitizedPath = sanitizedPath.replace(/\.\.\//g, '');
+      }
       const filePath = join(
         process.cwd(),
         UPLOAD_LOCATION || '',


### PR DESCRIPTION
Fixes [https://github.com/llong2195/nest-fastify/security/code-scanning/10](https://github.com/llong2195/nest-fastify/security/code-scanning/10)

To fix the problem, we need to ensure that all instances of `../` are removed from the path, not just the first occurrence. This can be achieved by repeatedly applying the regular expression replacement until no more replacements can be performed. This approach ensures that all instances of the targeted pattern are removed, effectively sanitizing the input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
